### PR TITLE
排序逻辑修改

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,28 +53,31 @@ INI 格式由多个 **section** 组成，其中 `genisolist.ini` 中以 `%` 开�
 - 单个 `location` 或一组 `location_{0..N-1}`（N 为数字，从 0 开始）：文件路径匹配的通配符（glob）规则，在参考实现中使用 `pathlib.Path.glob` 处理。生成器会根据 `root` 与 `location` 获取可能匹配的文件列表。
 - `pattern`：文件路径正则表达式规则。路径不匹配的文件会被忽略。可以使用可选字段中的 `pattern_use_name` 切换为使用文件名（而非路径）匹配。正则表达式中允许使用捕获组特性（即使用括号包裹的部分），被捕获的部分可以在 `version`、`type`、`platform`、`key_by`、`sort_by` 中使用。与其他软件类似，`$0` 代表整个匹配的字符串，`$1` 代表第一个捕获组，以此类推。不存在的匹配组以空字符串处理。可以在 <https://regex101.com/> 测试正则表达式行为。
 
-以下是可选字段：
+以下是可选字段。其中一个 *section* 可以由 `key_by` 字段划分为多个 *group*（默认整个 section 为一个 group），每个 group 内部稳定排序之后，能够输出的文件数量受到 `listvers` 限制。最后所有相同 `distro` 的 group 合并之后再次稳定排序。
 
-- `listvers`：每个版本列出的文件数量，默认为 255 个。
+- `listvers`：每个分组内部版本列出的文件数量，默认为 255 个。
 - `version`：版本号信息。脚本会尝试使用符合版本语义的方式比较不同的版本号。
 - `type`：文件类型，默认为空，应对 `version` 与 `platform` 字段无法覆盖的情况。
 - `platform`：平台信息。脚本会根据平台的优先级（常见以及重要程度）对不同平台、相同版本的文件排序。
 - `category`：分类，默认为 `os`，如果对应的文件为软件或者字体，则需要设置为 `app` 或 `font`。
-- `key_by`：Section 内子分组关键字，默认不分组。排序操作在子分组内进行，并且 `listvers` 限制变为对每个子分组内文件数量的限制。
-- `sort_by`：排序关键字，覆盖默认的排序规则。默认排序规则为按照以下值作为排序关键字逆序排序：
+- `key_by`：Section 内子分组关键字，默认不分组（整个分为一组）。
+- `sort_by`：（逆序稳定）排序关键字，覆盖默认的排序规则。默认排序规则为按照以下值作为排序关键字逆序稳定排序：
 
     ```python
-    (
+    [
         LooseVersion(file_item["version"]),
         get_platform_priority(file_item["platform"]),
         file_item["type"],
-    )
+    ]
     ```
 
-    `sort_by` 中的值应为空白符分割的捕获组。
+    `sort_by` 中的捕获组应被空白符分割。
 
-- `nosort`：布尔值。默认为 `false`。如果为 `true`，则不对文件进行排序。
 - `pattern_use_name`：布尔值。默认为 `false`。如果为 `true`，则 pattern 的正则表达式规则只使用文件名，而非整个文件路径进行正则匹配。
+
+被弃用的字段：
+
+- `nosort`：使用 `sort_by` 字段设置为常量字符串代替（排序操作仍会进行，由于排序是逆序的，最终的列表会反过来）。
 
 ### 输出格式
 

--- a/includes/app/minikube.ini
+++ b/includes/app/minikube.ini
@@ -1,7 +1,6 @@
 [minikube]
 distro = Minikube
 category = app
-nosort = true
 location = github-release/kubernetes/minikube/LatestRelease/*
 pattern = ([^/]+)(?<!sha256)$
 version = $1

--- a/includes/app/obs.ini
+++ b/includes/app/obs.ini
@@ -1,7 +1,6 @@
 [obs]
 distro = OBS
 category = app
-nosort = true
 location = github-release/obsproject/obs-studio/OBS*/*
 pattern = ([^/]+)\.(exe|zip|dmg)$
 version = $1

--- a/includes/app/orchestrator.ini
+++ b/includes/app/orchestrator.ini
@@ -1,7 +1,6 @@
 [orchestrator]
 distro = orchestrator
 category = app
-nosort = true
 location = github-release/openark/orchestrator/LatestRelease/*
 pattern = ([^/]+)$
 version = $1

--- a/includes/app/qt.ini
+++ b/includes/app/qt.ini
@@ -15,6 +15,5 @@ location = qt/official_releases/online_installers/qt-unified-*
 pattern = qt-unified-(.*?)-online.(run|dmg|exe)
 platform = $1
 version = Qt Online Installer
-nosort = true
 category = app
 

--- a/includes/app/rust-analyzer.ini
+++ b/includes/app/rust-analyzer.ini
@@ -1,7 +1,6 @@
 [rust-analyzer]
 distro = rust-analyzer
 category = app
-nosort = true
 location = github-release/rust-analyzer/rust-analyzer/LatestRelease/*
 pattern = ([^/]+)$
 version = $1

--- a/includes/font/google_fonts.ini
+++ b/includes/font/google_fonts.ini
@@ -4,7 +4,6 @@ location = github-release/googlefonts/*/*/*
 pattern = googlefonts/(noto-\w+)/(?!LatestRelease).*/(.+\.zip)
 version = $1 $2
 category = font
-nosort = true
 
 [googlefonts noto cjk]
 distro = Google Fonts

--- a/includes/os/kde_neon.ini
+++ b/includes/os/kde_neon.ini
@@ -3,6 +3,5 @@ distro = KDE neon
 location = kde-application/neon/images/*/current/*
 pattern = kde-application/neon/images/(.+)/current/neon-(.+)-current\.iso(?!.)
 version = $1
-nosort = true
 platform = iso
 

--- a/includes/os/ubuntukylin.ini
+++ b/includes/os/ubuntukylin.ini
@@ -6,5 +6,4 @@ pattern = ubuntukylin-([-\d\.\w]+)-([\w]+)-([\w]+)\.iso
 version = $1 $2 free
 type = iso
 platform = $3
-nosort = true
 


### PR DESCRIPTION
上一版的实现仅在 section 或者由 `key_by` 划出的组内排序，导致一些输出的选项顺序和预期不太相符：

![image](https://github.com/mirrorz-org/genisolist/assets/2109893/b4a9571f-b3c1-4cdb-bbf2-3b287f331462)

本版明确了 section 和 group 的定义，恢复至排序两次（group 内一次 + 所有项都获取后一次，首次排序是因为 `listvers` 需要在组内选取指定次数的最新的项），并且移除了可能导致困惑的 `nosort`（不排序的话是哪里不排序呢？）。