### PR TITLE
fix: Update conda.ini for latest packages

### DIFF
--- a/includes/app/conda.ini
+++ b/includes/app/conda.ini
@@ -2,49 +2,18 @@
 distro = Conda
 listvers = 1
 location = anaconda/archive/Anaconda*
-pattern = (Anaconda3)-([\d\.]+)-(Windows|Linux|MacOSX)-(x86_64|x86).(\w+)
+pattern = (Anaconda3)-([\d\.]+(?:-\d)?)-(Windows|Linux|MacOSX)-(x86_64|x86).(\w+)
 platform = $3/$4
 type = $5
 version = $1 $2
 category = app
 
-[anaconda2]
-distro = Conda
-listvers = 1
-location = anaconda/archive/Anaconda*
-pattern = (Anaconda2)-([\d\.]+)-(Windows|Linux|MacOSX)-(x86_64|x86).(\w+)
-platform = $3/$4
-type = $5
-version = $1 $2
-category = app
-
-[miniconda37]
+[miniconda3-latest]
 distro = Conda
 listvers = 1
 location = anaconda/miniconda/Miniconda*
-pattern = (Miniconda3-py37)_([\d\.]+)-(Windows|Linux|MacOSX)-(x86_64|x86).(\w+)
-platform = $3/$4
-type = $5
-version = $1 $2
+pattern = (Miniconda3-latest)-(Windows|Linux|MacOSX)-(x86_64|x86).(\w+)
+platform = $2/$3
+type = $4
+version = $1
 category = app
-
-[miniconda38]
-distro = Conda
-listvers = 1
-location = anaconda/miniconda/Miniconda*
-pattern = (Miniconda3-py38)_([\d\.]+)-(Windows|Linux|MacOSX)-(x86_64|x86).(\w+)
-platform = $3/$4
-type = $5
-version = $1 $2
-category = app
-
-[miniconda2]
-distro = Conda
-listvers = 1
-location = anaconda/miniconda/Miniconda*
-pattern = (Miniconda2)-([\d\.]+)-(Windows|Linux|MacOSX)-(x86_64|x86).(\w+)
-platform = $3/$4
-type = $5
-version = $1 $2
-category = app
-


### PR DESCRIPTION
- 移除了 Python2 相关的安装包（Anaconda2/Miniconda2）
- Miniconda 只匹配 latest（这样就不需要每个 Python 版本大更新都来更新这个配置了）
- Anaconda 匹配考虑类似 `2024.06-1` 的情况，否则最新的包匹配不上

<details>
<summary>TUNA's JSON output</summary>

```json
[
  {
    "distro": "Conda",
    "category": "app",
    "urls": [
      {
        "name": "Miniconda3-latest (Linux/x86, sh)",
        "url": "/anaconda/miniconda/Miniconda3-latest-Linux-x86.sh"
      },
      {
        "name": "Miniconda3-latest (Linux/x86_64, sh)",
        "url": "/anaconda/miniconda/Miniconda3-latest-Linux-x86_64.sh"
      },
      {
        "name": "Miniconda3-latest (MacOSX/x86, sh)",
        "url": "/anaconda/miniconda/Miniconda3-latest-MacOSX-x86.sh"
      },
      {
        "name": "Miniconda3-latest (MacOSX/x86_64, sh)",
        "url": "/anaconda/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
      },
      {
        "name": "Miniconda3-latest (MacOSX/x86_64, pkg)",
        "url": "/anaconda/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg"
      },
      {
        "name": "Miniconda3-latest (Windows/x86, exe)",
        "url": "/anaconda/miniconda/Miniconda3-latest-Windows-x86.exe"
      },
      {
        "name": "Miniconda3-latest (Windows/x86_64, exe)",
        "url": "/anaconda/miniconda/Miniconda3-latest-Windows-x86_64.exe"
      },
      {
        "name": "Anaconda3 2024.06-1 (Linux/x86_64, sh)",
        "url": "/anaconda/archive/Anaconda3-2024.06-1-Linux-x86_64.sh"
      },
      {
        "name": "Anaconda3 2024.06-1 (MacOSX/x86_64, sh)",
        "url": "/anaconda/archive/Anaconda3-2024.06-1-MacOSX-x86_64.sh"
      },
      {
        "name": "Anaconda3 2024.06-1 (MacOSX/x86_64, pkg)",
        "url": "/anaconda/archive/Anaconda3-2024.06-1-MacOSX-x86_64.pkg"
      },
      {
        "name": "Anaconda3 2024.06-1 (Windows/x86_64, exe)",
        "url": "/anaconda/archive/Anaconda3-2024.06-1-Windows-x86_64.exe"
      }
    ]
  }
]
```

</details>