### PR TITLE
feat: add r.ini for R

### DIFF
--- a/includes/app/r.ini
+++ b/includes/app/r.ini
@@ -3,7 +3,7 @@ distro = R
 location = CRAN/bin/windows/base/R-*-win.exe
 pattern = R-([\d\.]+\w*|devel)-win.exe
 platform = Windows
-listvers = 1
+listvers = 2
 version = $1
 category = app
 

--- a/includes/app/r.ini
+++ b/includes/app/r.ini
@@ -1,8 +1,17 @@
 [r-windows]
 distro = R
 location = CRAN/bin/windows/base/R-*-win.exe
-pattern = R-([\d\.]+\w*|devel)-win.exe
+pattern = R-([\d\.]+)-win.exe
 platform = Windows
+listvers = 1
+version = $1
+category = app
+
+[r-windows-unstable]
+distro = R
+location = CRAN/bin/windows/base/R-*-win.exe
+pattern = R-([\d\.]+patched|devel)-win.exe
+platform = Windows, unstable
 listvers = 2
 version = $1
 category = app

--- a/includes/app/r.ini
+++ b/includes/app/r.ini
@@ -1,0 +1,35 @@
+[r-windows]
+distro = R
+location = CRAN/bin/windows/base/R-*-win.exe
+pattern = R-([\d\.]+\w*|devel)-win.exe
+platform = Windows
+listvers = 1
+version = R $1
+category = app
+
+[r-macos-arm64]
+distro = R
+location = CRAN/bin/macosx/big-sur-arm64/base/R-*-arm64.pkg
+pattern = R-([\d\.]+)-arm64.pkg
+platform = macOS >= 11, arm64
+listvers = 1
+version = R $1
+category = app
+
+[r-macos-x86_64]
+distro = R
+location = CRAN/bin/macosx/big-sur-x86_64/base/R-*-x86_64.pkg
+pattern = R-([\d\.]+)-x86_64.pkg
+platform = macOS >= 11, x86_64
+listvers = 1
+version = R $1
+category = app
+
+[r-macos-legacy]
+distro = R
+location = CRAN/bin/macosx/base/R-*.pkg
+pattern = R-([\d\.]+).pkg
+platform = macOS >= 10.13
+listvers = 1
+version = R $1
+category = app

--- a/includes/app/r.ini
+++ b/includes/app/r.ini
@@ -4,7 +4,7 @@ location = CRAN/bin/windows/base/R-*-win.exe
 pattern = R-([\d\.]+\w*|devel)-win.exe
 platform = Windows
 listvers = 1
-version = R $1
+version = $1
 category = app
 
 [r-macos-arm64]
@@ -13,7 +13,7 @@ location = CRAN/bin/macosx/big-sur-arm64/base/R-*-arm64.pkg
 pattern = R-([\d\.]+)-arm64.pkg
 platform = macOS >= 11, arm64
 listvers = 1
-version = R $1
+version = $1
 category = app
 
 [r-macos-x86_64]
@@ -22,7 +22,7 @@ location = CRAN/bin/macosx/big-sur-x86_64/base/R-*-x86_64.pkg
 pattern = R-([\d\.]+)-x86_64.pkg
 platform = macOS >= 11, x86_64
 listvers = 1
-version = R $1
+version = $1
 category = app
 
 [r-macos-legacy]
@@ -31,5 +31,5 @@ location = CRAN/bin/macosx/base/R-*.pkg
 pattern = R-([\d\.]+).pkg
 platform = macOS >= 10.13
 listvers = 1
-version = R $1
+version = $1
 category = app


### PR DESCRIPTION
包括了 Windows 和 macOS 的安装包

Linux 构建以额外系统软件仓库的形式分发，不适合放入

Windows on Arm 的安装包[还没有通过 CRAN 分发](https://blog.r-project.org/2024/04/23/r-on-64-bit-arm-windows/)，到时候再修改

