### PR TITLE
feat(app/wireshark): stratoshark

### DIFF
--- a/includes/app/wireshark.ini
+++ b/includes/app/wireshark.ini
@@ -28,3 +28,22 @@ platform = $1
 type = dmg
 category = app
 
+[stratoshark win]
+distro = Wireshark
+listvers = 1
+location = wireshark/win64/*
+pattern = Stratoshark-([^-]+)-([^/]+)\.exe
+version = Stratoshark $1
+platform = $2
+type = exe
+category = app
+
+[stratoshark osx]
+distro = Wireshark
+listvers = 1
+location = wireshark/osx/*.dmg
+pattern = Stratoshark ([^ ]+) ([^/]+)\.dmg
+version = Stratoshark $1
+platform = $2
+type = dmg
+category = app


### PR DESCRIPTION
```json
{
  "distro": "Wireshark",
  "category": "app",
  "urls": [
    {
      "name": "latest (x64, msi)",
      "url": "/wireshark/win64/Wireshark-latest-x64.msi"
    },
    {
      "name": "latest (x64, exe, PortableApps)",
      "url": "/wireshark/win64/WiresharkPortable64_latest.paf.exe"
    },
    {
      "name": "latest (arm64, exe)",
      "url": "/wireshark/win64/Wireshark-latest-arm64.exe"
    },
    {
      "name": "latest (x64, exe)",
      "url": "/wireshark/win64/Wireshark-latest-x64.exe"
    },
    {
      "name": "latest (Intel 64, dmg)",
      "url": "/wireshark/osx/Wireshark Latest Intel 64.dmg"
    },
    {
      "name": "latest (Arm 64, dmg)",
      "url": "/wireshark/osx/Wireshark Latest Arm 64.dmg"
    },
    {
      "name": "Stratoshark 0.9.0rc1 (x64, exe)",
      "url": "/wireshark/win64/Stratoshark-0.9.0rc1-x64.exe"
    },
    {
      "name": "Stratoshark 0.9.0rc1 (arm64, exe)",
      "url": "/wireshark/win64/Stratoshark-0.9.0rc1-arm64.exe"
    },
    {
      "name": "Stratoshark 0.9.0rc1 (Arm 64, dmg)",
      "url": "/wireshark/osx/Stratoshark 0.9.0rc1 Arm 64.dmg"
    },
    {
      "name": "Stratoshark 0.9.0rc1 (Intel 64, dmg)",
      "url": "/wireshark/osx/Stratoshark 0.9.0rc1 Intel 64.dmg"
    }
  ]
}
```

目前 Stratoshark 版本号不是纯数字（带 rc）所以用分隔符来匹配

此外目前已经可以用最大的版本号定位到最新版本，考虑是否撤回 #13 中对 Wireshark 版本号的变更