### PR TITLE
refactor(app/virtualbox): split platforms

### DIFF
--- a/includes/app/virtualbox.ini
+++ b/includes/app/virtualbox.ini
@@ -34,6 +34,15 @@ platform = Guest Additions, iso
 version = $1
 category = app
 
+[virtualbox-sdk]
+distro = VirtualBox
+listvers = 1
+location = virtualbox/*/*
+pattern = VirtualBoxSDK-([\d\.]+)-\d+.zip
+platform = SDK
+version = $1
+category = app
+
 #[virtualbox-extpack]
 #distro = VirtualBox
 #listvers = 1

--- a/includes/app/virtualbox.ini
+++ b/includes/app/virtualbox.ini
@@ -1,9 +1,44 @@
-[virtualbox]
+[virtualbox-windows]
 distro = VirtualBox
 listvers = 1
-location = virtualbox/virtualbox-*
-pattern = virtualbox-(.*?)-(latest).(exe|dmg)
-platform = $1
-version = $2
+location = virtualbox/*/*
+pattern = VirtualBox-([\d\.]+)-\d+-Win.exe
+platform = Windows hosts
+version = $1
 category = app
 
+[virtualbox-macos]
+distro = VirtualBox
+listvers = 1
+location = virtualbox/*/*
+pattern = VirtualBox-([\d\.]+)-\d+-OSX.dmg
+platform = macOS / Intel hosts
+version = $1
+category = app
+
+[virtualbox-macos-aarch64]
+distro = VirtualBox
+listvers = 1
+location = virtualbox/*/*
+pattern = VirtualBox-([\d\.]+)-\d+-macOSArm64.dmg
+platform = macOS / Apple Silicon hosts
+version = $1
+category = app
+
+[virtualbox-guest-additions]
+distro = VirtualBox
+listvers = 1
+location = virtualbox/*/*
+pattern = VBoxGuestAdditions_([\d\.]+).iso
+platform = Guest Additions, iso
+version = $1
+category = app
+
+#[virtualbox-extpack]
+#distro = VirtualBox
+#listvers = 1
+#location = virtualbox/*/*
+#pattern = Oracle_VirtualBox_Extension_Pack-([\d\.]+).vbox-extpack
+#platform = Extension Pack
+#version = $1
+#category = app


### PR DESCRIPTION
```json
{
  "distro": "VirtualBox",
  "category": "app",
  "urls": [
    {
      "name": "7.1.4 (Windows hosts)",
      "url": "/virtualbox/7.1.4/VirtualBox-7.1.4-165100-Win.exe"
    },
    {
      "name": "7.1.4 (macOS / Intel hosts)",
      "url": "/virtualbox/7.1.4/VirtualBox-7.1.4-165100-OSX.dmg"
    },
    {
      "name": "7.1.4 (macOS / Apple Silicon hosts)",
      "url": "/virtualbox/7.1.4/VirtualBox-7.1.4-165100-macOSArm64.dmg"
    },
    {
      "name": "7.1.4 (Guest Additions, iso)",
      "url": "/virtualbox/7.1.4/VBoxGuestAdditions_7.1.4.iso"
    },
    {
      "name": "7.1.4 (SDK)",
      "url": "/virtualbox/7.1.4/VirtualBoxSDK-7.1.4-165100.zip"
    }
  ]
}
```

拆分各平台的逻辑，并添加 Guest Additions 和 SDK

神必闭源扩展已注释，需要的可以自行加回去
