### PR TITLE
fix(app/github/stellarium): releases for platforms

### DIFF
--- a/includes/app/github/Stellarium.ini
+++ b/includes/app/github/Stellarium.ini
@@ -5,7 +5,7 @@ location = github-release/Stellarium/stellarium/LatestRelease/*
 pattern = stellarium-([\d\.]+)-qt(\d)-win(32|64)\.exe$
 version = $1
 platform = Windows, x86_$3
-type = Qt $2
+type = Qt$2
 category = app
 
 [stellarium-windows-arm64]
@@ -15,7 +15,7 @@ location = github-release/Stellarium/stellarium/LatestRelease/*
 pattern = stellarium-([\d\.]+)-qt(\d)-arm64\.exe$
 version = $1
 platform = Windows, ARM64
-type = Qt $2
+type = Qt$2
 category = app
 
 [stellarium-macos]
@@ -25,7 +25,7 @@ location = github-release/Stellarium/stellarium/LatestRelease/*
 pattern = Stellarium-([\d\.]+)-qt(\d)-macOS\.zip$
 version = $1
 platform = macOS
-type = Qt $2
+type = Qt$2
 category = app
 
 [stellarium-linux]
@@ -34,8 +34,8 @@ listvers = 1
 location = github-release/Stellarium/stellarium/LatestRelease/*
 pattern = Stellarium-([\d\.]+)-qt(\d)-x86_64\.AppImage$
 version = $1
-platform = Linux, x86_64
-type = Qt $2
+platform = Linux, amd64
+type = Qt$2
 category = app
 
 [stellarium-user-guide]

--- a/includes/app/github/Stellarium.ini
+++ b/includes/app/github/Stellarium.ini
@@ -1,10 +1,48 @@
-[stellarium]
+[stellarium-windows]
 distro = Stellarium
 listvers = 1
 location = github-release/Stellarium/stellarium/LatestRelease/*
-pattern = (\w+)-([\d\.-]+)[\.-](tar\.gz|pdf|zip|win\d+\.exe|\w+\.AppImage)(?!.)
-version = $1 $2
-platform = $3
-key_by = $1
+pattern = stellarium-([\d\.]+)-qt(\d)-win(32|64)\.exe$
+version = $1
+platform = Windows, x86_$3
+type = Qt $2
 category = app
 
+[stellarium-windows-arm64]
+distro = Stellarium
+listvers = 1
+location = github-release/Stellarium/stellarium/LatestRelease/*
+pattern = stellarium-([\d\.]+)-qt(\d)-arm64\.exe$
+version = $1
+platform = Windows, ARM64
+type = Qt $2
+category = app
+
+[stellarium-macos]
+distro = Stellarium
+listvers = 1
+location = github-release/Stellarium/stellarium/LatestRelease/*
+pattern = Stellarium-([\d\.]+)-qt(\d)-macOS\.zip$
+version = $1
+platform = macOS
+type = Qt $2
+category = app
+
+[stellarium-linux]
+distro = Stellarium
+listvers = 1
+location = github-release/Stellarium/stellarium/LatestRelease/*
+pattern = Stellarium-([\d\.]+)-qt(\d)-x86_64\.AppImage$
+version = $1
+platform = Linux, x86_64
+type = Qt $2
+category = app
+
+[stellarium-user-guide]
+distro = Stellarium
+listvers = 1
+location = github-release/Stellarium/stellarium/LatestRelease/*
+pattern = stellarium_user_guide-([\d\.]+)[\d\.-]*\.pdf$
+version = $1
+platform = User Guide
+category = app


### PR DESCRIPTION
```json
[
  {
    "distro": "Stellarium",
    "category": "app",
    "urls": [
      {
        "name": "24.4 (Linux, amd64, Qt6)",
        "url": "/github-release/Stellarium/stellarium/LatestRelease/Stellarium-24.4-qt6-x86_64.AppImage"
      },
      {
        "name": "24.4 (Linux, amd64, Qt5)",
        "url": "/github-release/Stellarium/stellarium/LatestRelease/Stellarium-24.4-qt5-x86_64.AppImage"
      },
      {
        "name": "24.4 (Windows, x86_64, Qt6)",
        "url": "/github-release/Stellarium/stellarium/LatestRelease/stellarium-24.4-qt6-win64.exe"
      },
      {
        "name": "24.4 (Windows, x86_64, Qt5)",
        "url": "/github-release/Stellarium/stellarium/LatestRelease/stellarium-24.4-qt5-win64.exe"
      },
      {
        "name": "24.4 (Windows, ARM64, Qt6)",
        "url": "/github-release/Stellarium/stellarium/LatestRelease/stellarium-24.4-qt6-arm64.exe"
      },
      {
        "name": "24.4 (Windows, x86_32, Qt5)",
        "url": "/github-release/Stellarium/stellarium/LatestRelease/stellarium-24.4-qt5-win32.exe"
      },
      {
        "name": "24.4 (macOS, Qt6)",
        "url": "/github-release/Stellarium/stellarium/LatestRelease/Stellarium-24.4-qt6-macOS.zip"
      },
      {
        "name": "24.4 (User Guide)",
        "url": "/github-release/Stellarium/stellarium/LatestRelease/stellarium_user_guide-24.4-1.pdf"
      }
    ]
  }
]
```