### PR TITLE
fix(os/fedora): fix f42 pattern matching

### DIFF
--- a/includes/os/fedora.ini
+++ b/includes/os/fedora.ini
@@ -1,20 +1,20 @@
 [fedora_workstation]
 distro = Fedora
 listvers = 2
-location_0 = fedora/releases/[1-9][0-9]/Workstation/*/iso/Fedora-Workstation-Live-*-[1-9][0-9]-*.iso
-pattern = Fedora-Workstation-Live-(\w+)-(\d+)-.*\.iso
-version = $2
+location_0 = fedora/releases/[1-9][0-9]/Workstation/*/iso/Fedora-Workstation-Live-*-*.iso
+pattern = Fedora-Workstation-Live-(\d*)([a-zA-Z][a-zA-Z0-9_]*)?-(?:(\d+)-)?[\d\.]+([a-zA-Z][a-zA-Z0-9_]*)?\.iso
+version = $1$3
 type = Live CD with standard workstation desktop environment
-platform = $1
+platform = $2$4
 
 [fedora_spins]
 distro = Fedora
 listvers = 2
-location_0 = fedora/releases/[1-9][0-9]/Spins/*/iso/Fedora-*-Live-*-[1-9][0-9]-*.iso
-pattern = Fedora-(\w+)-Live-(\w+)-(\d+)-.*\.iso
-version = $3
+location_0 = fedora/releases/[1-9][0-9]/Spins/*/iso/Fedora-*-Live-*-*.iso
+pattern = Fedora-(\w+)-Live-(\d*)([a-zA-Z][a-zA-Z0-9_]*)?-(?:(\d+)-)?[\d\.]+([a-zA-Z][a-zA-Z0-9_]*)?\.iso
+version = $2$4
 type = Live CD with $1
-platform = $2
+platform = $3$5
 
 [fedora_server]
 distro = Fedora


### PR DESCRIPTION
目前 Fedora 42 Workstation 版本使用的文件名已经不适合旧的匹配规则，导致网站上相关页面没有 F42 版本的 Workstation 获取链接。镜像文件似乎可以同步。

同时发现部分 Spin 存在相似的问题，本 PR 一并修正了 Spin 的匹配逻辑。

测试过的字符串包括:

workstation

```text
Fedora-Workstation-Live-42-1.1.x86_64.iso
Fedora-Workstation-Live-x86_64-41-1.4.iso
```

Spin

```text
Fedora-Xfce-Live-42-1.1.x86_64.iso
Fedora-Sway-Live-x86_64-42-1.1.iso
Fedora-LXDE-Live-x86_64-41-1.4.iso
```