### PR TITLE
feat(os): add Fedora KDE Desktop configuration

### DIFF
--- a/includes/os/fedora.ini
+++ b/includes/os/fedora.ini
@@ -43,3 +43,12 @@ version = $3
 type = Everything $1
 platform = $2
 
+[fedora_kde]
+distro = Fedora
+listvers = 2
+location_0 = fedora/releases/[1-9][0-9]/KDE/*/iso/Fedora-KDE-Desktop-Live-*-*.iso
+pattern = Fedora-KDE-Desktop-Live-(\d+)-[\d\.]+(\w+)\.iso
+version = $1
+type = KDE Desktop
+platform = $2
+


### PR DESCRIPTION
Add support for Fedora KDE Desktop edition which is located in the separate `KDE/` directory.

This adds a new configuration section [fedora_kde] to handle Fedora KDE Desktop ISO files like:
- `Fedora-KDE-Desktop-Live-43-1.6.x86_64.iso`

The files are located at: `fedora/releases/<version>/KDE/<arch>/iso/`