### PR TITLE
fix: show the version number of noto-cjk zip in googlefonts

### DIFF
--- a/includes/font/github/googlefonts.ini
+++ b/includes/font/github/googlefonts.ini
@@ -1,8 +1,11 @@
 [google fonts]
 distro = Google Fonts
 location = github-release/googlefonts/*/*/*
-pattern = googlefonts/(noto-\w+)/(?!LatestRelease).*/(.+\.zip)
-version = $1 $2
+# This pattern matches all ZIP files except those in LatestRelease, and has special treatment for names of recent Noto CJK releases.
+# https://regex101.com/r/aPUKIG/1
+pattern = googlefonts/(noto-\w+)/(?!LatestRelease)(?:Noto (Sans|Serif) CJK Version ([.\d]+) \(.+\)|.*)/(.+\.zip)
+# For Noto CJK, the file name ($4) already contains Sans/Serif ($2). However, Sans and Serif are versioned separately. To avoid confusion, we put Sans/Serif before the version number ($3) even though it is redundant.
+version = $1 $2 $3 $4
 category = font
 
 [googlefonts noto cjk]


### PR DESCRIPTION
At present, https://mirrors.nju.edu.cn/download/Google%20Fonts and https://mirrors.cernet.edu.cn/font/GoogleFonts list multiple versions of Noto Serif CJK, but the links do not show version numbers. We have to hover the links and check the URLs.

This PR adds version numbers before the filenames.
Refer to the comments in `googlefonts.ini` for details.

Current:
- noto-cjk 15_NotoSerifTC.zip (zip)
- noto-cjk 15_NotoSerifTC.zip (zip)
- noto-cjk 15_NotoSansMonoCJKhk.zip (zip)
- noto-cjk 14_NotoSerifSC.zip (zip)
- noto-cjk 14_NotoSerifSC.zip (zip)
- noto-cjk 14_NotoSansMonoCJKtc.zip (zip)

This PR:
- noto-cjk Serif 2.003 15_NotoSerifTC.zip (zip)
- noto-cjk Serif 2.003 14_NotoSerifSC.zip (zip)
- noto-cjk Serif 2.002 15_NotoSerifTC.zip (zip)
- noto-cjk Serif 2.002 14_NotoSerifSC.zip (zip)
- noto-cjk Sans 2.004 15_NotoSansMonoCJKhk.zip (zip)
- noto-cjk Sans 2.004 14_NotoSansMonoCJKtc.zip (zip)

Besides, it might be better to create a dedicated `[google fonts noto cjk zip]`, but I don't know if it's safe to split an entry.

---


Relates-to: https://github.com/mirrorz-org/mirrorz-help/issues/257
Note that I didn't handle OTF/SubsetOTF/… or sc/tc/hk/… here, because that would be too hacky. (mirrorz-help/docs is more suitable.)
